### PR TITLE
NotifyMove in WebSocketsService.cs in WebDav lacked one line

### DIFF
--- a/CS/WebDAVServer.FileSystemStorage.AspNet/WebSocketsService.cs
+++ b/CS/WebDAVServer.FileSystemStorage.AspNet/WebSocketsService.cs
@@ -102,11 +102,13 @@ namespace WebDAVServer.FileSystemStorage.AspNet
         /// <summary>
         /// Notifies client that file/folder was moved.
         /// </summary>
-        /// <param name="itemPath">file/folder path.</param>
+        /// <param name="itemPath">old file/folder path.</param>
+        /// <param name="targetPath">new file/folder path.</param>
         /// <returns></returns>
         public async Task NotifyMovedAsync(string itemPath, string targetPath)
         {
             itemPath = itemPath.Trim('/');
+            targetPath = targetPath.Trim('/');
             MovedNotification notifyObject = new MovedNotification
             {
                 ItemPath = itemPath,

--- a/CS/WebDAVServer.FileSystemStorage.AspNetCore.Cookies/WebDAVServerImpl/WebSocketsService.cs
+++ b/CS/WebDAVServer.FileSystemStorage.AspNetCore.Cookies/WebDAVServerImpl/WebSocketsService.cs
@@ -93,11 +93,13 @@ namespace WebDAVServer.FileSystemStorage.AspNetCore.Cookies
         /// <summary>
         /// Notifies client that file/folder was moved.
         /// </summary>
-        /// <param name="itemPath">file/folder path.</param>
+        /// <param name="itemPath">old file/folder path.</param>
+        /// <param name="targetPath">new file/folder path.</param>
         /// <returns></returns>
         public async Task NotifyMovedAsync(string itemPath, string targetPath)
         {
             itemPath = itemPath.Trim('/');
+            targetPath = targetPath.Trim('/');
             MovedNotification notifyObject = new MovedNotification
             {
                 ItemPath = itemPath,

--- a/CS/WebDAVServer.FileSystemStorage.AspNetCore/WebSocketsService.cs
+++ b/CS/WebDAVServer.FileSystemStorage.AspNetCore/WebSocketsService.cs
@@ -93,11 +93,13 @@ namespace WebDAVServer.FileSystemStorage.AspNetCore
         /// <summary>
         /// Notifies client that file/folder was moved.
         /// </summary>
-        /// <param name="itemPath">file/folder path.</param>
+        /// <param name="itemPath">old file/folder path.</param>
+        /// <param name="targetPath">new file/folder path.</param>
         /// <returns></returns>
         public async Task NotifyMovedAsync(string itemPath, string targetPath)
         {
             itemPath = itemPath.Trim('/');
+            targetPath = targetPath.Trim('/');
             MovedNotification notifyObject = new MovedNotification
             {
                 ItemPath = itemPath,

--- a/CS/WebDAVServer.FileSystemStorage.HttpListener/WebSocketsService.cs
+++ b/CS/WebDAVServer.FileSystemStorage.HttpListener/WebSocketsService.cs
@@ -102,11 +102,13 @@ namespace WebDAVServer.FileSystemStorage.HttpListener
         /// <summary>
         /// Notifies client that file/folder was moved.
         /// </summary>
-        /// <param name="itemPath">file/folder path.</param>
+        /// <param name="itemPath">old file/folder path.</param>
+        /// <param name="targetPath">new file/folder path.</param>
         /// <returns></returns>
         public async Task NotifyMovedAsync(string itemPath, string targetPath)
         {
             itemPath = itemPath.Trim('/');
+            targetPath = targetPath.Trim('/');
             MovedNotification notifyObject = new MovedNotification
             {
                 ItemPath = itemPath,

--- a/CS/WebDAVServer.SqlStorage.AspNet/WebSocketsService.cs
+++ b/CS/WebDAVServer.SqlStorage.AspNet/WebSocketsService.cs
@@ -102,11 +102,13 @@ namespace WebDAVServer.SqlStorage.AspNet
         /// <summary>
         /// Notifies client that file/folder was moved.
         /// </summary>
-        /// <param name="itemPath">file/folder path.</param>
+        /// <param name="itemPath">old file/folder path.</param>
+        /// <param name="targetPath">new file/folder path.</param>
         /// <returns></returns>
         public async Task NotifyMovedAsync(string itemPath, string targetPath)
         {
             itemPath = itemPath.Trim('/');
+            targetPath = targetPath.Trim('/');
             MovedNotification notifyObject = new MovedNotification
             {
                 ItemPath = itemPath,

--- a/CS/WebDAVServer.SqlStorage.AspNetCore/WebSocketsService.cs
+++ b/CS/WebDAVServer.SqlStorage.AspNetCore/WebSocketsService.cs
@@ -93,11 +93,13 @@ namespace WebDAVServer.SqlStorage.AspNetCore
         /// <summary>
         /// Notifies client that file/folder was moved.
         /// </summary>
-        /// <param name="itemPath">file/folder path.</param>
+        /// <param name="itemPath">old file/folder path.</param>
+        /// <param name="targetPath">new file/folder path.</param>
         /// <returns></returns>
         public async Task NotifyMovedAsync(string itemPath, string targetPath)
         {
             itemPath = itemPath.Trim('/');
+            targetPath = targetPath.Trim('/');
             MovedNotification notifyObject = new MovedNotification
             {
                 ItemPath = itemPath,

--- a/CS/WebDAVServer.SqlStorage.HttpListener/WebSocketsService.cs
+++ b/CS/WebDAVServer.SqlStorage.HttpListener/WebSocketsService.cs
@@ -102,11 +102,13 @@ namespace WebDAVServer.SqlStorage.HttpListener
         /// <summary>
         /// Notifies client that file/folder was moved.
         /// </summary>
-        /// <param name="itemPath">file/folder path.</param>
+        /// <param name="itemPath">old file/folder path.</param>
+        /// <param name="targetPath">new file/folder path.</param>
         /// <returns></returns>
         public async Task NotifyMovedAsync(string itemPath, string targetPath)
         {
             itemPath = itemPath.Trim('/');
+            targetPath = targetPath.Trim('/');
             MovedNotification notifyObject = new MovedNotification
             {
                 ItemPath = itemPath,


### PR DESCRIPTION
There is one line missing in the WebsocketsService to also trim the targetPath. Due to this, the notification while moving an item can in some circumstances not work.
It looks like, the line went missing due to a copy and paste error.